### PR TITLE
HTML attributes

### DIFF
--- a/src/types/html/attribute-value.js
+++ b/src/types/html/attribute-value.js
@@ -1,25 +1,25 @@
 import isAttributeSupported, { getElementInterface, getAttributeJsName } from './attribute.js';
 
 let dummies = {};
+let cached = {};
 
-export default function attributeValue (name, value, {elementType = '_', elementInterface = getElementInterface(elementType)} = {}) {
+export default function attributeValue (
+	name,
+	value,
+	{ elementType = '_', elementInterface = getElementInterface(elementType) } = {},
+) {
 	cached[elementType] ??= {};
 	cached[elementType][name] ??= {};
 
 	let cachedResult = cached[elementType][name][value];
-	if (cachedResult !== undefined) {
-		let success = Boolean(cachedResult);
-		return {success, attribute: attributeSupported};
+	if (cachedResult) {
+		return cachedResult;
 	}
 
-	let attributeSupported = isAttributeSupported(name, {elementType, elementInterface});
-	if (!attributeSupported.success) {
-		return attributeSupported;
-	}
-
+	let attributeSupported = isAttributeSupported(name, { elementType, elementInterface });
 	let jsName = attributeSupported.jsName;
-	let elementInterface = attributeSupported.elementInterface;
-	let element = dummies[elementType] ??= document.createElement(elementType);
+	elementInterface = attributeSupported.elementInterface;
+	let element = (dummies[elementType] ??= document.createElement(elementType));
 
 	let defaultValue = element[jsName];
 	let isBoolean = typeof defaultValue === 'boolean';
@@ -29,7 +29,11 @@ export default function attributeValue (name, value, {elementType = '_', element
 	element[jsName] = defaultValue;
 
 	let success;
-	if (isBoolean && result === true && typeof value !== 'boolean') {
+	if (isBoolean && (value === '' || name === value.toLowerCase())) {
+		// Support cases like hidden="", hidden="hidden" (case insensitive), etc.
+		success = true;
+	}
+	else if (isBoolean && result === true && typeof value !== 'boolean') {
 		// Boolean attribute expanded to take values, but doesn't support the value
 		// Example: hidden="until-found" not supported, but hidden is
 		success = false;
@@ -42,5 +46,5 @@ export default function attributeValue (name, value, {elementType = '_', element
 		success = true;
 	}
 
-	return {success, attribute: attributeSupported};
+	return (cached[elementType][name][value] = { success, attribute: attributeSupported });
 }

--- a/src/types/html/attribute.js
+++ b/src/types/html/attribute.js
@@ -5,7 +5,7 @@ let elementInterfaces = {};
 /**
  * Irregular cases that can't be determined by `camelCase()`
  */
-let irregularAttributes = {
+export const irregularAttributes = {
 	contenteditable: 'contentEditable',
 	readonly: 'readOnly',
 	for: 'htmlFor',

--- a/src/types/html/attribute.js
+++ b/src/types/html/attribute.js
@@ -1,10 +1,32 @@
-import { dummy } from '../../shared.js';
 import { camelCase } from '../../util.js';
 
 let elementInterfaces = {};
 
+/**
+ * Irregular cases that can't be determined by `camelCase()`
+ */
+let irregularAttributes = {
+	contenteditable: 'contentEditable',
+	readonly: 'readOnly',
+	for: 'htmlFor',
+	class: 'className',
+	tabindex: 'tabIndex',
+	maxlength: 'maxLength',
+	minlength: 'minLength',
+	colspan: 'colSpan',
+	rowspan: 'rowSpan',
+	usemap: 'useMap',
+	ismap: 'isMap',
+	datetime: 'dateTime',
+	autocapitalize: 'autoCapitalize',
+	autofocus: 'autoFocus',
+	autoplay: 'autoPlay',
+	playsinline: 'playsInline',
+	crossorigin: 'crossOrigin',
+};
+
 export function getElementInterface (elementType) {
-	if (!elementType || elementType.includes("-")) {
+	if (!elementType || elementType.includes('-')) {
 		return HTMLElement;
 	}
 
@@ -29,25 +51,23 @@ export function getElementInterface (elementType) {
 }
 
 export function getAttributeJsName (attributeName) {
-	// Irregular cases that can't be determined by camelCase()
-	switch (attributeName) {
-		case 'contenteditable':
-			return 'contentEditable';
-		case 'readonly':
-			return 'readOnly';
-		case 'for':
-			return 'htmlFor';
-	}
-
-	return camelCase(attributeName);
+	return irregularAttributes[attributeName] ?? camelCase(attributeName);
 }
 
-export default function attribute (name, {jsName = camelCase(name), elementType = '_', elementInterface = getElementInterface(elementType)} = {}) {
+export default function attribute (
+	name,
+	{
+		jsName = getAttributeJsName(name),
+		elementType = '_',
+		elementInterface = getElementInterface(elementType),
+	} = {},
+) {
 	try {
-		return jsName in elementInterface.prototype;
+		let success = jsName in elementInterface.prototype;
+		return { success, jsName, elementInterface };
 	}
 	catch (error) {
 		// Unknown properties don't throw errors
-		return {success: true, jsName, elementInterface};
+		return { success: true, jsName, elementInterface };
 	}
 }

--- a/src/types/html/index-fn.js
+++ b/src/types/html/index-fn.js
@@ -1,5 +1,3 @@
 export { default as htmlElement } from './element.js';
-
-// Uncomment when we know these work
-// export { default as htmlAttribute } from './attribute.js';
-// export { default as htmlAttributeValue } from './attribute-value.js';
+export { default as htmlAttribute } from './attribute.js';
+export { default as htmlAttributeValue } from './attribute-value.js';

--- a/src/types/html/index.js
+++ b/src/types/html/index.js
@@ -1,4 +1,3 @@
 export { default as element } from './element.js';
-// Uncomment when we know these work
-// export { default as attribute } from './attribute.js';
-// export { default as attributeValue } from './attribute-value.js';
+export { default as attribute } from './attribute.js';
+export { default as attributeValue } from './attribute-value.js';


### PR DESCRIPTION
## Summary

### Refactor `attribute.js`

- Introduce `irregularAttributes` mapping for HTML attributes that don't map cleanly via `camelCase()` (e.g., `contenteditable` -> `contentEditable`, `readonly` -> `readOnly`, `for` -> `htmlFor`, etc.).
- Refactor `getAttributeJsName()` to replace the previous switch-based logic in favor of `irregularAttributes`.
- Refactor `attribute()` to:
    - compute `jsName` with `getAttributeJsName()`,
    - return `{ success, jsName, elementInterface }` instead of a bare boolean, while preserving the try/catch behavior.

### Refactor `attribute-value.js`

- Cache `attributeValue()` results per element type, attribute name, and value. Return cached result objects directly when available.
- Adjust boolean-attribute support logic to accept empty string and case-insensitive repeated-name values (e.g., `hidden=“"`, `hidden=“hidden”`) as valid. Preserve previous behavior for unsupported boolean value cases and store computed results in the cache before returning.

### Expose the new functions

### Prettier